### PR TITLE
portability: add ECL, CCL and ABCL to supported implementations.

### DIFF
--- a/cells.asd
+++ b/cells.asd
@@ -1,6 +1,6 @@
 ;;;; -*- Mode: Lisp; Syntax: ANSI-Common-Lisp; Base: 10 -*-
 
-#+(or allegro lispworks cmu mcl clisp cormanlisp sbcl scl)
+#+(or allegro lispworks cmu mcl clisp cormanlisp sbcl scl ecl ccl abcl)
 (progn
 (declaim (optimize (debug 3) (speed 3) (safety 1) (compilation-speed 0)))
 

--- a/defpackage.lisp
+++ b/defpackage.lisp
@@ -30,13 +30,16 @@
    #+allegro #:excl
    #+clisp #:clos
    #+cmu #:mop
+   #+abcl #:mop
    #+cormanlisp #:common-lisp
    #+lispworks #:clos
    #+sbcl #:sb-mop
+   #+ecl #:clos
    #+openmcl-partial-mop #:openmcl-mop
    #+(and mcl (not openmcl-partial-mop)) #:ccl
+   #+(and ccl (not openmcl-partial-mop)) #:ccl
    
-   #-(or allegro clisp cmu cormanlisp lispworks mcl sbcl)
+   #-(or allegro clisp cmu ccl cormanlisp lispworks mcl sbcl ecl abcl)
    #.(cerror "Provide a package name."
        "Don't know how to find the MOP package for this Lisp.")
    


### PR DESCRIPTION
with pull request on utils-kt cells load and at least support basic stuff (idk cells yet, used example) on these three.