### PR TITLE
change prog1 to progn & find-class to avoid warnings

### DIFF
--- a/defmodel.lisp
+++ b/defmodel.lisp
@@ -48,11 +48,11 @@
                                        `(,',reader-fn self)))
                                    #+sbcl (unless (fboundp ',reader-fn)
                                             (defgeneric ,reader-fn (slot)))))))))
-     
+
      ;
      ; -------  defclass ---------------  (^slot-value ,model ',',slotname)
      ;
-     (prog1
+     (progn
          (defclass ,class ,(or directsupers '(model-object)) ;; now we can def the class
            ,(mapcar (lambda (s)
                       (list* (car s)
@@ -111,7 +111,8 @@ the defmodel form for ~a" ',class ',class))))
                                   (md-slot-value self ',slotname)))
                             ,(when unchanged-if
                                `(def-c-unchanged-test (,class ,slotname) ,unchanged-if)))))))
-           slotspecs))
+                 slotspecs)
+       (find-class ',class))
      (loop for slotspec in ',slotspecs
          do (destructuring-bind
                 (slotname &rest slotargs &key (cell t) owning &allow-other-keys)


### PR DESCRIPTION
Hi Kenny, I love the idea of using this library but am running into some warnings on sbcl.

I'm getting the "can't find type for specializer BAR" warnings because `defmodel` puts `defclass` in a `prog1` which is not a top level form.

The advantage of putting `defclass` in `prog1` seems to be it returns the class object, but we could do this by using find-class in the tail position of the progn.

It's a bit hacky but seems to work on sbcl. Would be interested in your findings.

Thanks for the great work